### PR TITLE
Fix parameters in Safari on macOS and iOS by reading the form data wh…

### DIFF
--- a/wifimgr.py
+++ b/wifimgr.py
@@ -289,6 +289,13 @@ def start(port=80):
             except OSError:
                 pass
 
+            # Handle form data from Safari on macOS and iOS; it sends \r\n\r\nssid=<ssid>&password=<password>
+            try:
+                request += client.recv(512)
+                print("Received form data after \\r\\n\\r\\n(i.e. from Safari on macOS or iOS)")
+            except OSError:
+                pass
+
             print("Request is: {}".format(request))
             if "HTTP" not in request:  # skip invalid requests
                 continue


### PR DESCRIPTION
…ich appears after `\r\n\r\n` (HTTP POST data was verified with WireShark).